### PR TITLE
trim shopify helpers

### DIFF
--- a/.changeset/fuzzy-poets-sneeze.md
+++ b/.changeset/fuzzy-poets-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@bsmnt/shopify-helpers": major
+"@bsmnt/sdk-gen": patch
+---
+
+Remove createStandardStorefrontClient as it was too big with no real benefit for now

--- a/packages/sdk-gen/src/generate.ts
+++ b/packages/sdk-gen/src/generate.ts
@@ -95,8 +95,7 @@ function createDirIfDoesNotExist(p: string) {
 
 const extraGenerated = `import type { Config } from "@bsmnt/sdk-gen";
 
-// @ts-ignore
-const fetch = global.fetch || require("isomorphic-unfetch");
+const fetch = globalThis.fetch || require("isomorphic-unfetch");
 
 type ClientOptions = {
   noThrowOnErrors?: boolean;

--- a/packages/shopify-helpers/README.md
+++ b/packages/shopify-helpers/README.md
@@ -1,6 +1,6 @@
 # @bsmnt/shopify-helpers
 
-Internal, legacy use only. Although you can install at your risk:
+Internal use only (for now). Install at your risk:
 
 ```zsh
 yarn add @bsmnt/shopify-helpers
@@ -8,5 +8,4 @@ yarn add @bsmnt/shopify-helpers
 
 Exports:
 
-- `createStandardShopifyStorefrontSdk`: _function_ to create a shopify storefront sdk with pre made queries. We generally recommend you don't use this, and actually create the queries that fit your use case.
-- `useProductHelper`: _Hook_ that helps manage product state, such as options available, options selected, and variant selected.
+- `useProductFormHelper`: _Hook_ that helps manage product form state, such as options available, options selected, and variant selected.

--- a/packages/shopify-helpers/src/index.ts
+++ b/packages/shopify-helpers/src/index.ts
@@ -1,2 +1,2 @@
-export { createStandardShopifyStorefrontSdk } from "./sdk-gen/sdk";
-export { useProductHelper } from "./product-helper";
+// export { createStandardShopifyStorefrontSdk } from "./sdk-gen/sdk";
+export { useProductFormHelper } from './product-form-helper'

--- a/packages/shopify-helpers/src/product-form-helper/index.tsx
+++ b/packages/shopify-helpers/src/product-form-helper/index.tsx
@@ -1,88 +1,88 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from 'react'
 
-import type { _ProductFragment } from "../sdk-gen/generated";
+import type { _ProductFragment } from '../sdk-gen/generated'
 
 type BareBonesVariant = Pick<
-  _ProductFragment["variants"]["edges"][0]["node"],
-  "availableForSale" | "compareAtPriceV2" | "priceV2" | "selectedOptions" | "id"
->;
+  _ProductFragment['variants']['edges'][0]['node'],
+  'availableForSale' | 'compareAtPriceV2' | 'priceV2' | 'selectedOptions' | 'id'
+>
 
 type BareBonesProduct = Pick<
   _ProductFragment,
-  "options" | "availableForSale"
+  'options' | 'availableForSale'
 > & {
-  variants: { edges: Array<{ node: BareBonesVariant }> };
-} & { [key: string]: unknown };
+  variants: { edges: Array<{ node: BareBonesVariant }> }
+} & { [key: string]: unknown }
 
-export const useProductHelper = (product: BareBonesProduct) => {
+export const useProductFormHelper = (product: BareBonesProduct) => {
   const [selectedOptions, setSelectedOptions] = useState<
     Record<string, string | undefined>
   >(() => {
-    const opts: Record<string, string | undefined> = {};
+    const opts: Record<string, string | undefined> = {}
 
     product.options.forEach((o) => {
-      if (o.name.toLowerCase() !== "title") opts[o.name] = undefined;
-    });
+      if (o.name.toLowerCase() !== 'title') opts[o.name] = undefined
+    })
 
-    return opts;
-  });
+    return opts
+  })
 
   const handleSelectOption = useCallback(
     (name: string, value: string | undefined) =>
       setSelectedOptions((p) => ({ ...p, [name]: value })),
     []
-  );
+  )
 
   const selectedVariant = useMemo(() => {
-    if (product.variants.edges.length === 1) return product.variants.edges[0];
+    if (product.variants.edges.length === 1) return product.variants.edges[0]
 
-    const _selectedOptions = Object.entries(selectedOptions);
+    const _selectedOptions = Object.entries(selectedOptions)
     const selectedVariant = product.variants.edges.find((variant) => {
       return _selectedOptions.every(([name, value]) =>
         variant.node.selectedOptions.find(
           (option) => option.name === name && option.value === value
         )
-      );
-    });
+      )
+    })
 
-    return selectedVariant;
-  }, [selectedOptions, product.variants]);
+    return selectedVariant
+  }, [selectedOptions, product.variants])
 
   const optionsToSelect = useMemo(
     () =>
       product.options
-        .filter((o) => o.name.toLowerCase() !== "title")
+        .filter((o) => o.name.toLowerCase() !== 'title')
         .map((option) => ({
           ...option,
           values: option.values.map((value) => {
             const variants = product.variants.edges.filter((variant) => {
               return variant.node.selectedOptions.every((optionInVariant) => {
                 if (optionInVariant.name === option.name) {
-                  return optionInVariant.value === value;
+                  return optionInVariant.value === value
                 } else if (selectedOptions[optionInVariant.name]) {
                   return (
                     optionInVariant.value ===
                     selectedOptions[optionInVariant.name]
-                  );
+                  )
                 } else {
-                  return true;
+                  return true
                 }
-              });
-            });
+              })
+            })
 
             const isNotAvailable = variants.every((v) =>
               v ? !v.node.availableForSale : true
-            );
+            )
 
-            return { value, disabled: isNotAvailable };
-          }),
+            return { value, disabled: isNotAvailable }
+          })
         })),
     [product.options, product.variants.edges, selectedOptions]
-  );
+  )
 
   const { hasOneOptionSelected, hasAllOptionsSelected, hasNoOptions } =
     useMemo(() => {
-      const selectedOptionsKeys = Object.keys(selectedOptions);
+      const selectedOptionsKeys = Object.keys(selectedOptions)
       return {
         hasOneOptionSelected: selectedOptionsKeys.some(
           (o) => !!selectedOptions[o]
@@ -90,27 +90,27 @@ export const useProductHelper = (product: BareBonesProduct) => {
         hasAllOptionsSelected: selectedOptionsKeys.every(
           (o) => !!selectedOptions[o]
         ),
-        hasNoOptions: selectedOptionsKeys.length === 0,
-      };
-    }, [selectedOptions]);
+        hasNoOptions: selectedOptionsKeys.length === 0
+      }
+    }, [selectedOptions])
 
   const discount = useMemo(() => {
-    if (!selectedVariant || !selectedVariant.node.compareAtPriceV2) return null;
+    if (!selectedVariant || !selectedVariant.node.compareAtPriceV2) return null
     const raw =
       selectedVariant.node.priceV2.amount -
-      selectedVariant.node.compareAtPriceV2.amount;
+      selectedVariant.node.compareAtPriceV2.amount
     const percentage =
-      (raw / selectedVariant.node.compareAtPriceV2.amount) * 100;
-    return { percentage, raw };
-  }, [selectedVariant]);
+      (raw / selectedVariant.node.compareAtPriceV2.amount) * 100
+    return { percentage, raw }
+  }, [selectedVariant])
 
   const isProductSoldOut = useMemo(() => {
-    return !product.availableForSale;
-  }, [product.availableForSale]);
+    return !product.availableForSale
+  }, [product.availableForSale])
 
   const isSelectedVariantSoldOut = useMemo(() => {
-    return selectedVariant?.node.availableForSale;
-  }, [selectedVariant]);
+    return selectedVariant?.node.availableForSale
+  }, [selectedVariant])
 
   return {
     handleSelectOption,
@@ -122,6 +122,6 @@ export const useProductHelper = (product: BareBonesProduct) => {
     selectedOptions,
     hasOneOptionSelected,
     hasAllOptionsSelected,
-    hasNoOptions,
-  };
-};
+    hasNoOptions
+  }
+}


### PR DESCRIPTION
This pr removes `createStandardStorefrontClient` from `shopify-helpers`, as it was making the package too big with no real benefit for now.

This also patches `sdk-gen` to use `globalThis` instead of `global` to access `fetch`